### PR TITLE
feat: sampler exclusion by attr regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,18 @@ Goal is to follow https://opentelemetry.io/docs/specs/semconv/http/http-spans/
 
 ## Sampler
 
-If sampling needs are simple then `cowboy_otel_sampler` can be useful to exclude
-a span called `<<"GET /metrics">>` with configuration:
+The `cowboy_otel_sampler` supports dropping traces with by any named attribute matching a regexp.
+
+If a single attribute match, then the span is dropped.
+
+Here is a way to apply it only for root spans, i.e. if it is a health check.
 
 ```
 {opentelemetry, [
-    {sampler, {parent_based, #{root => {cowboy_otel_sampler, [<<"GET /metrics">>]}}}}
+    {sampler, {parent_based, #{root => {cowboy_otel_sampler, #{'http.route' => <<"^/livez">>}}}}}
     ]}
 ```
 
-This sampler will exclude spans of kind server whose name is in the provided list.
 
 ## Tests
 

--- a/src/cowboy_otel_middleware.erl
+++ b/src/cowboy_otel_middleware.erl
@@ -33,10 +33,13 @@ http_method(#{method := Method}) -> Method.
 
 http_route(#{path := Path, bindings := Bindings}) ->
     RouteFun = fun
-        (_, <<>>, Acc) -> Acc;
+        (_, <<>>, Acc) ->
+            Acc;
         (K, V, Acc) when is_binary(K) -> binary:replace(Acc, V, <<":", K/binary>>);
-        (K, V, Acc) when is_atom(K) -> binary:replace(Acc, V, <<":", (atom_to_binary(K, utf8))/binary>>);
-        (_, _, Acc) -> Acc
+        (K, V, Acc) when is_atom(K) ->
+            binary:replace(Acc, V, <<":", (atom_to_binary(K, utf8))/binary>>);
+        (_, _, Acc) ->
+            Acc
     end,
     maps:fold(RouteFun, Path, Bindings);
 http_route(_) ->

--- a/src/cowboy_otel_sampler.erl
+++ b/src/cowboy_otel_sampler.erl
@@ -9,16 +9,71 @@
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
 -include_lib("opentelemetry/include/otel_sampler.hrl").
 
-setup(BinList) when is_binary(hd(BinList)) ->
-    #{exclude => BinList};
-setup(String) ->
-    #{exclude => string:split(binary:list_to_bin(String), ",")}.
+%% setup/1 expects a map of Attribute Names to Regex string patterns.
+%% Example config: #{'http.route' => <<"^(/metrics|/livez)">>}
+setup(ExcludeMap) when is_map(ExcludeMap) ->
+    %% Pre-compile the regular expressions once for performance
+    CompiledRules = maps:fold(
+        fun(AttrKey, Pattern, Acc) ->
+            {ok, CompiledRegex} = re:compile(Pattern),
+            [{AttrKey, CompiledRegex} | Acc]
+        end,
+        [],
+        ExcludeMap
+    ),
+    #{exclude_rules => CompiledRules}.
 
-description(#{exclude := List}) ->
-    iolist_to_binary(io_lib:format("Exclude spans from set ~p", [List])).
+description(#{exclude_rules := Rules}) ->
+    Keys = [K || {K, _} <- Rules],
+    iolist_to_binary(io_lib:format("Exclude spans matching attributes: ~p", [Keys])).
 
-should_sample(_Ctx, _TraceId, _Links, Name, Kind, _Attrs, #{exclude := List}) ->
-    case Kind == ?SPAN_KIND_SERVER andalso lists:member(Name, List) of
-        true -> {?DROP, [], []};
-        _ -> {?RECORD_AND_SAMPLE, [], []}
+should_sample(_Ctx, _TraceId, _Links, _Name, _Kind, Attrs, #{exclude_rules := Rules}) ->
+    %% Check if the span's attributes match any of our exclusion rules
+    case matches_any_rule(Attrs, Rules) of
+        true ->
+            {?DROP, [], []};
+        false ->
+            {?RECORD_AND_SAMPLE, [], []}
     end.
+
+%% =====================================================================
+%% Internal Helper Functions
+%% =====================================================================
+
+matches_any_rule(_Attrs, []) ->
+    false;
+matches_any_rule(Attrs, [{AttrKey, CompiledRegex} | Rest]) ->
+    case get_attribute(AttrKey, Attrs) of
+        undefined ->
+            %% Attribute not present, check the next rule
+            matches_any_rule(Attrs, Rest);
+        Value ->
+            %% Attribute present, check if it matches the regex
+            BinValue = to_binary(Value),
+            case re:run(BinValue, CompiledRegex) of
+                %% Regex matched, we should DROP
+                {match, _} -> true;
+                %% No match, check next
+                nomatch -> matches_any_rule(Attrs, Rest)
+            end
+    end.
+
+%% Safely extracts the attribute value from the Attrs map.
+get_attribute(Key, Attrs) when is_atom(Key) ->
+    BinKey = to_binary(Key),
+    case Attrs of
+        #{Key := Value} ->
+            Value;
+        #{BinKey := Value} ->
+            Value;
+        _ ->
+            undefined
+    end.
+
+%% re:run/2 requires a subject to be a string or binary.
+%% We safely cast the attribute value just in case it's an integer or atom.
+to_binary(V) when is_binary(V) -> V;
+to_binary(V) when is_atom(V) -> atom_to_binary(V, utf8);
+to_binary(V) when is_list(V) -> iolist_to_binary(V);
+to_binary(V) when is_integer(V) -> integer_to_binary(V);
+to_binary(V) -> iolist_to_binary(io_lib:format("~p", [V])).

--- a/test/sampler_SUITE.erl
+++ b/test/sampler_SUITE.erl
@@ -37,7 +37,6 @@ end_per_group(sampler, _Config) ->
     ok.
 
 init_per_testcase(sampled_spans, Config) ->
-    ct:pal("All registerd processes ~p", [erlang:registered()]),
     %%sys:trace(otel_simple_processor_global, true),
     Tid = ets:new(export_tab, [
         public,

--- a/test/sampler_SUITE.erl
+++ b/test/sampler_SUITE.erl
@@ -10,55 +10,63 @@
 -include_lib("opentelemetry/include/otel_span.hrl").
 
 all() ->
-    [sampled_spans].
+    [{group, sampler}].
+
+groups() ->
+    [{sampler, [], [sampled_spans]}].
 
 init_per_suite(Config) ->
     application:load(opentelemetry),
-    Sampler = {parent_based, #{root => {cowboy_otel_sampler, [<<"GET /exclude">>]}}},
-    ExporterSpec = {otel_exporter_stdout, []},
-    Processor = {otel_simple_processor, #{exporter => ExporterSpec}},
-    application:set_env(opentelemetry, sampler, Sampler),
-    application:set_env(opentelemetry, processors, [Processor]),
-    {ok, _} = application:ensure_all_started(opentelemetry),
-    [
-        {exporter, ExporterSpec}
-        | Config
-    ].
+    Config.
 
 end_per_suite(_Config) ->
-    _ = application:stop(opentelemetry),
     _ = application:unload(opentelemetry),
     ok.
 
+init_per_group(sampler, Config) ->
+    application:set_env(opentelemetry, span_processors, otel_simple_processor),
+    application:set_env(opentelemetry, traces_exporter, {otel_exporter_stdout, []}),
+    CowboySampler = {cowboy_otel_sampler, #{'http.route' => <<"^(/metrics|/heartbeat)$">>}},
+    Sampler = {parent_based, #{root => CowboySampler}},
+    application:set_env(opentelemetry, sampler, Sampler),
+    {ok, _} = application:ensure_all_started(opentelemetry),
+    Config.
+
+end_per_group(sampler, _Config) ->
+    _ = application:stop(opentelemetry),
+    ok.
+
 init_per_testcase(sampled_spans, Config) ->
+    ct:pal("All registerd processes ~p", [erlang:registered()]),
+    %%sys:trace(otel_simple_processor_global, true),
     Tid = ets:new(export_tab, [
         public,
         duplicate_bag,
         {keypos, #span.trace_id}
     ]),
-    otel_simple_processor:set_exporter(otel_exporter_tab, Tid),
-    %% sys:trace(otel_simple_processor_global, true),
+    otel_simple_processor:set_exporter(otel_exporter_tab, Tid), 
     [{tid, Tid} | Config].
 
 end_per_testcase(sampled_spans, Config) ->
-    {Exporter, ExporterSpec} = ?config(exporter, Config),
-    otel_simple_processor:set_exporter(Exporter, ExporterSpec),
-    %% sys:trace(otel_simple_processor_global, false),
     Tid = ?config(tid, Config),
+    ct:pal("In sampled table ~n~p", [ets:tab2list(Tid)]),
     ets:delete(Tid),
+    sys:trace(otel_simple_processor_global, false),
     ok.
 
 sampled_spans(Config) ->
     Tid = ?config(tid, Config),
 
-    SpanCtx1 = mock_http_server_span(<<"GET">>, <<"/pre/success">>),
-    SpanCtx2 = mock_http_server_span(<<"GET">>, <<"/exclude">>),
-    SpanCtx3 = mock_http_server_span(<<"GET">>, <<"/post/success">>),
+    SpanCtx1 = mock_http_server_span(<<"GET">>, <<"/pre/unfiltered">>),
+    SpanCtxGone1 = mock_http_server_span(<<"GET">>, <<"/metrics">>),
+    SpanCtxGone2 = mock_http_server_span(<<"GET">>, <<"/heartbeat">>),
+    SpanCtx2 = mock_http_server_span(<<"GET">>, <<"/post/unfiltered">>),
 
     ?assertEqual(2 * 2, ets:info(Tid, size)),
     ?assert(ets:member(Tid, otel_span:trace_id(SpanCtx1))),
-    ?assert(not ets:member(Tid, otel_span:trace_id(SpanCtx2))),
-    ?assert(ets:member(Tid, otel_span:trace_id(SpanCtx3))),
+    ?assert(not ets:member(Tid, otel_span:trace_id(SpanCtxGone1))),
+    ?assert(not ets:member(Tid, otel_span:trace_id(SpanCtxGone2))),
+    ?assert(ets:member(Tid, otel_span:trace_id(SpanCtx2))),
 
     ok.
 
@@ -68,8 +76,8 @@ mock_http_server_span(Method, Route) ->
         #{
             kind => server,
             attributes => #{
-                <<"http.method">> => Method,
-                <<"http.route">> => Route
+                'http.method' => Method,
+                'http.route' => Route
             }
         },
     ?with_span(


### PR DESCRIPTION
You are supposed to configure your sampler like this (parent_based optional, but it tends to be what you want).

```
{opentelemetry, [...
    {sampler,  {parent_based, #{root => {cowboy_otel_sampler, #{'http.route' => <<"^(/metrics|/heartbeat)$">>}}}},
    ...
    ]}
```

so root traces in this services are dropped if the 'http.route' or ~"http.route" attribute with a value matching the regexp will be dropped and not sampled.

